### PR TITLE
Update bazaar layout with grid columns

### DIFF
--- a/frontend/src/components/bazaar/Bazaar.js
+++ b/frontend/src/components/bazaar/Bazaar.js
@@ -204,7 +204,12 @@ export default function Bazaar() {
     <div className="relative w-full min-h-screen overflow-x-hidden">
       <InteractiveBackground />
 
-      <div className="relative z-10 flex">
+      <div
+        className="relative z-10 grid"
+        style={{
+          gridTemplateColumns: panelItem ? '15vw 1fr 28vw' : '15vw 1fr',
+        }}
+      >
         <div className="sticky top-0 p-4 overflow-y-auto w-[15vw] min-w-[200px] h-screen">
           <div className="mb-6">
             <p className="text-white font-bold mb-2">Slot:</p>
@@ -250,7 +255,7 @@ export default function Bazaar() {
           </div>
         </div>
 
-         <div className={`flex-grow p-6 ${panelItem ? 'w-[calc(100%-15vw-28vw-1.5rem)]' : 'w-[calc(100%-15vw-1.5rem)]'} transition-all duration-300`}>
+        <div className="p-6 transition-all duration-300">
           {isAdmin && (
             <div className="mb-4">
               <div className="flex flex-wrap gap-2">
@@ -294,12 +299,16 @@ export default function Bazaar() {
                  <p className="text-center text-gray-400 mt-8">Nessun oggetto trovato corrispondente ai filtri.</p>
              )}
           </div>
-        </div>
+        {panelItem && (
+          <AnimatePresence>
+            <ComparisonPanel
+              item={panelItem}
+              showMessage={displayConfirmation}
+              key={`comparisonPanel-${panelItem.id}`}
+            />
+          </AnimatePresence>
+        )}
       </div>
-
-      <AnimatePresence>
-         {panelItem && <ComparisonPanel item={panelItem} showMessage={displayConfirmation} key={`comparisonPanel-${panelItem.id}`} />}
-      </AnimatePresence>
 
       {showOverlay && (
         <AddWeaponOverlay

--- a/frontend/src/components/bazaar/elements/comparisonComponent.js
+++ b/frontend/src/components/bazaar/elements/comparisonComponent.js
@@ -239,14 +239,8 @@ export default function ComparisonPanel({ item, showMessage }) { // Added showMe
                 animate={{ x: 0, opacity: 1 }}
                 exit={{ x: 300, opacity: 0 }}
                 transition={{ duration: 0.3 }}
-                className="fixed right-0 p-0 overflow-y-auto z-50 rounded-l-lg overflow-hidden shadow-2xl border-l border-gray-700"
-                style={{
-                    top: '10rem',
-                    width: '28vw',
-                    maxWidth: '450px',
-                    height: 'calc(100vh - 12rem)',
-                    maxHeight: '700px'
-                }}
+                className="p-0 overflow-y-auto z-50 rounded-l-lg overflow-hidden shadow-2xl border-l border-gray-700"
+                style={{ width: '100%' }}
             >
                 <div className="relative h-full bg-gray-900">
                     {/* Confirmation Dialog */}


### PR DESCRIPTION
## Summary
- switch bazaar layout container from flex to grid
- remove width calculations for item list and rely on grid columns
- make `ComparisonPanel` part of the grid layout instead of fixed positioning

## Testing
- `npm test --silent` *(fails: react-scripts not found)*